### PR TITLE
Fixed BottomBar not changing item highlight, added support for automaticallyImplyLeading in AppBar

### DIFF
--- a/packages/native_widgets/lib/app_bar/app_bar.dart
+++ b/packages/native_widgets/lib/app_bar/app_bar.dart
@@ -11,6 +11,7 @@ class NativeAppBar extends StatelessWidget implements PreferredSizeWidget {
   // final bool showMaterial;
   // final ValueChanged<dynamic> onValueChanged;
   // final dynamic groupValue;
+  final bool automaticallyImplyLeading;
   final MaterialAppBarData android;
   final CupertinoNavigationBarData ios;
 
@@ -28,6 +29,7 @@ class NativeAppBar extends StatelessWidget implements PreferredSizeWidget {
     this.preferredSize = const Size.fromHeight(56.0),
     // this.groupValue,
     // this.onValueChanged,
+    this.automaticallyImplyLeading,
     this.ios,
     this.android,
   });
@@ -86,6 +88,7 @@ class NativeAppBar extends StatelessWidget implements PreferredSizeWidget {
       title: title,
       trailingActions: actions,
       leading: leading,
+      automaticallyImplyLeading:automaticallyImplyLeading,
       ios: (BuildContext context) => ios,
       android: (BuildContext context) => android,
     );

--- a/packages/native_widgets/lib/scaffold/scaffold.dart
+++ b/packages/native_widgets/lib/scaffold/scaffold.dart
@@ -330,6 +330,7 @@ class NativeScaffold extends StatelessWidget {
               leading: appBar?.leading,
               title: appBar?.title,
               trailingActions: appBar?.actions,
+              automaticallyImplyLeading: appBar?.automaticallyImplyLeading,
             ),
       body: body,
       bottomNavBar: bottomBar?.items == null

--- a/packages/native_widgets/lib/scaffold/scaffold.dart
+++ b/packages/native_widgets/lib/scaffold/scaffold.dart
@@ -337,6 +337,7 @@ class NativeScaffold extends StatelessWidget {
           : PlatformNavBar(
               itemChanged: bottomBar?.onTap,
               items: bottomBar?.items,
+              currentIndex: bottomBar?.currentIndex,
             ),
     );
   }


### PR DESCRIPTION
Added current index to NativeScaffold's PlatformNavBar.
Added automaticallyImplyLeading to allow hidden leading element in AppBar.