### PR TITLE
Add support of nullItems to the ResponsiveScaffold constructor

### DIFF
--- a/packages/responsive_scaffold/lib/responsive_scaffold.dart
+++ b/packages/responsive_scaffold/lib/responsive_scaffold.dart
@@ -40,7 +40,7 @@ class ResponsiveScaffold extends StatelessWidget {
     this.mobileRootNavigator = false,
     this.mobileNavigator,
   }) : childDelagate = SliverChildListDelegate(
-          children,
+          children ?? <Widget>[nullItems ?? Center(child: CircularProgressIndicator())],
           addAutomaticKeepAlives: false,
           addRepaintBoundaries: false,
           addSemanticIndexes: false,


### PR DESCRIPTION
I'm playing with `ResponsiveScaffold` constructor, where I can pass widgets directly to the `children` property, and it seems to lack support of handy `nullItems` helper property.

This PR adds support for `nullItems`, and, additionally, provides default widget (`CircularProgressIndicator()` ) in case both `children` and `nullItems` are null.

I'm not sure this is the best way to handle this `null children` case, and maybe it's a bad practice to provide own widget, so feel free to suggest any changes.