### PR TITLE
flutter_sms: minSdkVersion, fix crash on Android, add canSendSMS

### DIFF
--- a/packages/flutter_sms/android/build.gradle
+++ b/packages/flutter_sms/android/build.gradle
@@ -35,7 +35,3 @@ android {
         disable 'InvalidPackage'
     }
 }
-
-dependencies {
-    api 'androidx.appcompat:appcompat:1.0.0-beta01'
-}

--- a/packages/flutter_sms/android/build.gradle
+++ b/packages/flutter_sms/android/build.gradle
@@ -27,7 +27,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 18
+        minSdkVersion 16
         targetSdkVersion 28
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/packages/flutter_sms/android/src/main/java/com/appleeducate/fluttersms/FlutterSmsPlugin.java
+++ b/packages/flutter_sms/android/src/main/java/com/appleeducate/fluttersms/FlutterSmsPlugin.java
@@ -3,6 +3,7 @@ package com.appleeducate.fluttersms;
 import android.Manifest;
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.ActivityInfo;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.provider.Settings;
@@ -31,10 +32,21 @@ public class FlutterSmsPlugin implements MethodCallHandler {
   @Override
   public void onMethodCall(MethodCall call, Result result) {
     if (call.method.equals("sendSMS")) {
+      if (!canSendSMS()) {
+        result.error(
+          "device_not_capable",
+          "The current device is not capable of sending text messages.",
+          "A device may be unable to send messages if it does not support messaging or if it is not currently configured to send messages. This only applies to the ability to send text messages via iMessage, SMS, and MMS."
+        );
+        return;
+      }
+
       String message = call.argument("message");
       String recipients = call.argument("recipients");
       sendSMS(recipients, message);
       result.success("SMS Sent!" );
+    } else if (call.method.equals("canSendSMS")) {
+      result.success(canSendSMS());
     } else {
       result.notImplemented();
     }
@@ -44,13 +56,24 @@ public class FlutterSmsPlugin implements MethodCallHandler {
     this.activity = activity;
   }
 
+  private boolean canSendSMS() {
+    if (!activity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELEPHONY))
+      return false;
+
+    Intent intent = new Intent(Intent.ACTION_VIEW);
+    intent.setData(Uri.parse("smsto:"));
+    ActivityInfo activityInfo = intent.resolveActivityInfo(activity.getPackageManager(), intent.getFlags());
+    if (activityInfo == null || !activityInfo.exported)
+      return false;
+
+    return true;
+  }
+
   private void sendSMS(String phones, String message) {
-     Intent intent = new Intent(Intent.ACTION_VIEW);
-     intent.setData(Uri.parse("smsto:" + phones));
-     intent.putExtra("sms_body", message);
+    Intent intent = new Intent(Intent.ACTION_VIEW);
+    intent.setData(Uri.parse("smsto:" + phones));
+    intent.putExtra("sms_body", message);
 //     intent.putExtra(Intent.EXTRA_STREAM, attachment);
-     if (intent.resolveActivity( activity.getPackageManager()) != null) {
-       activity.startActivity(intent);
-     }
+    activity.startActivity(intent);
   }
 }

--- a/packages/flutter_sms/android/src/main/java/com/appleeducate/fluttersms/FlutterSmsPlugin.java
+++ b/packages/flutter_sms/android/src/main/java/com/appleeducate/fluttersms/FlutterSmsPlugin.java
@@ -12,7 +12,6 @@ import android.util.Log;
 import java.util.ArrayList;
 import java.util.Arrays;
 
-import androidx.core.app.ActivityCompat;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;

--- a/packages/flutter_sms/android/src/main/java/com/appleeducate/fluttersms/FlutterSmsPlugin.java
+++ b/packages/flutter_sms/android/src/main/java/com/appleeducate/fluttersms/FlutterSmsPlugin.java
@@ -59,7 +59,7 @@ public class FlutterSmsPlugin implements MethodCallHandler {
     if (!activity.getPackageManager().hasSystemFeature(PackageManager.FEATURE_TELEPHONY))
       return false;
 
-    Intent intent = new Intent(Intent.ACTION_VIEW);
+    Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setData(Uri.parse("smsto:"));
     ActivityInfo activityInfo = intent.resolveActivityInfo(activity.getPackageManager(), intent.getFlags());
     if (activityInfo == null || !activityInfo.exported)
@@ -69,9 +69,10 @@ public class FlutterSmsPlugin implements MethodCallHandler {
   }
 
   private void sendSMS(String phones, String message) {
-    Intent intent = new Intent(Intent.ACTION_VIEW);
+    Intent intent = new Intent(Intent.ACTION_SENDTO);
     intent.setData(Uri.parse("smsto:" + phones));
     intent.putExtra("sms_body", message);
+    intent.putExtra(Intent.EXTRA_TEXT, message);
 //     intent.putExtra(Intent.EXTRA_STREAM, attachment);
     activity.startActivity(intent);
   }

--- a/packages/flutter_sms/example/lib/main.dart
+++ b/packages/flutter_sms/example/lib/main.dart
@@ -40,6 +40,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   TextEditingController _controllerPeople, _controllerMessage;
   String _message, body;
+  String _canSendSMSMessage = "Check is not run.";
   List<String> people = [];
 
   @override
@@ -54,9 +55,19 @@ class _MyAppState extends State<MyApp> {
   }
 
   void _sendSMS(String message, List<String> recipents) async {
-    String _result =
-        await FlutterSms.sendSMS(message: message, recipients: recipents);
-    setState(() => _message = _result);
+    try {
+      String _result =
+          await FlutterSms.sendSMS(message: message, recipients: recipents);
+      setState(() => _message = _result);
+    } catch (error) {
+      setState(() => _message = error.toString());
+    }
+  }
+
+  void _canSendSMS() async {
+    bool _result = await FlutterSms.canSendSMS();
+    setState(() => _canSendSMSMessage =
+        _result ? 'This unit can send SMS' : 'This unit cannot send SMS');
   }
 
   Widget _phoneTile(String name) {
@@ -191,6 +202,31 @@ class _MyAppState extends State<MyApp> {
                 ),
               ],
             ),
+            Divider(),
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: Text(
+                "Can send SMS",
+                style: Theme.of(context).textTheme.title,
+              ),
+            ),
+            Padding(
+                padding: const EdgeInsets.all(8),
+                child: Text(_canSendSMSMessage,
+                    style: Theme.of(context).textTheme.body1)),
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24),
+              child: RaisedButton(
+                color: Theme.of(context).accentColor,
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Text("RUN CHECK",
+                    style: Theme.of(context).accentTextTheme.button),
+                onPressed: () {
+                  _canSendSMS();
+                },
+              ),
+            )
           ],
         ),
       ),

--- a/packages/flutter_sms/ios/Classes/SwiftFlutterSmsPlugin.swift
+++ b/packages/flutter_sms/ios/Classes/SwiftFlutterSmsPlugin.swift
@@ -40,6 +40,18 @@ public class SwiftFlutterSmsPlugin: NSObject, FlutterPlugin, UINavigationControl
           )
         }
       #endif
+
+    case "canSendSMS":
+      #if targetEnvironment(simulator)
+        result(false)
+      #else
+        if (MFMessageComposeViewController.canSendText()) {
+          result(true)
+        } else {
+          result(false)
+        }
+      #endif
+
     default:
         result(FlutterMethodNotImplemented)
       break

--- a/packages/flutter_sms/lib/flutter_sms.dart
+++ b/packages/flutter_sms/lib/flutter_sms.dart
@@ -18,11 +18,7 @@ class FlutterSms {
       final String result = await _channel.invokeMethod('sendSMS', mapData);
       return result;
     } else {
-      String _phones = "";
-      for (var p in recipients) {
-        _phones += p + ",";
-      }
-      _phones = _phones.substring(0, _phones.length - 1);
+      String _phones = recipients.join(",");
       mapData["recipients"] = _phones;
       final String result = await _channel.invokeMethod('sendSMS', mapData);
       return result;

--- a/packages/flutter_sms/lib/flutter_sms.dart
+++ b/packages/flutter_sms/lib/flutter_sms.dart
@@ -24,4 +24,9 @@ class FlutterSms {
       return result;
     }
   }
+
+  static Future<bool> canSendSMS() async {
+    final bool result = await _channel.invokeMethod('canSendSMS');
+    return result;
+  }
 }


### PR DESCRIPTION
- Reduce minSdkVersion to 16
- Fix crash on android when `recipients` is empty (substring on empty string)
- Add `canSendSMS` API
  - Checks if device is SMS capable (iOS and Android)
  - Checks if `smsto:` Intent is resolved and resulting activity exported (Android)
- sendSMS: Return error when device is not SMS capable (Android)
- Remove unused AndroidX dependency
- Use Intent.ACTION_SENDTO and Intent.EXTRA_TEXT to increase message app support coverage