### PR TITLE
Latest simulators of iOS 13 are playing midi files

### DIFF
--- a/packages/flutter_midi/ios/Classes/SwiftFlutterMidiPlugin.swift
+++ b/packages/flutter_midi/ios/Classes/SwiftFlutterMidiPlugin.swift
@@ -14,10 +14,6 @@ public class SwiftFlutterMidiPlugin: NSObject, FlutterPlugin {
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    #if targetEnvironment(simulator)
-      let message = "Could Not Load Midi on this Device. (Cannot run on simulator), have you included the sound font?"
-      result(message)
-    #else
     switch call.method {
       case "prepare_midi":
        var map = call.arguments as? Dictionary<String, String>
@@ -59,6 +55,5 @@ public class SwiftFlutterMidiPlugin: NSObject, FlutterPlugin {
         result(FlutterMethodNotImplemented)
         break
     }
-    #endif
   }
 }


### PR DESCRIPTION
The conditional compilation is not required anymore as the latest version of the iOS13 simulators from Xcode 11 from Catalina 10.15 can play the midi files with no issue.