### PR TITLE
Fix issue in flutter_midi where Android platform calls were not being fully resolved.

### DIFF
--- a/packages/flutter_midi/android/src/main/java/com/appleeducate/fluttermidi/FlutterMidiPlugin.java
+++ b/packages/flutter_midi/android/src/main/java/com/appleeducate/fluttermidi/FlutterMidiPlugin.java
@@ -88,7 +88,7 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         e.printStackTrace();
       }
     } else {
-      result.notImplemented();
+      result.success(null);
     }
   }
 }

--- a/packages/flutter_midi/android/src/main/java/com/appleeducate/fluttermidi/FlutterMidiPlugin.java
+++ b/packages/flutter_midi/android/src/main/java/com/appleeducate/fluttermidi/FlutterMidiPlugin.java
@@ -40,10 +40,10 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         recv = synth.getReceiver();
         result.success("success");
       } catch (IOException e) {
-        result.error(e.getMessage());
+        result.error("error", e.getMessage(), null);
         e.printStackTrace();
       } catch (MidiUnavailableException e) {
-        result.error(e.getMessage());
+        result.error("error", e.getMessage(), null);
         e.printStackTrace();
       }
     } else if (call.method.equals("change_sound")) {
@@ -59,10 +59,10 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         recv = synth.getReceiver();
         result.success("success");
       } catch (IOException e) {
-        result.error(e.getMessage());
+        result.error("error", e.getMessage(), null);
         e.printStackTrace();
       } catch (MidiUnavailableException e) {
-        result.error(e.getMessage());
+        result.error("error", e.getMessage(), null);
         e.printStackTrace();
       }
     } else if (call.method.equals("play_midi_note")) {
@@ -73,7 +73,7 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         recv.send(msg, -1);
         result.success("success");
       } catch (InvalidMidiDataException e) {
-        result.error(e.getMessage());
+        result.error("error", e.getMessage(), null);
         e.printStackTrace();
       }
     } else if (call.method.equals("stop_midi_note")) {
@@ -84,7 +84,7 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         recv.send(msg, -1);
         result.success("success");
       } catch (InvalidMidiDataException e) {
-        result.error(e.getMessage());
+        result.error("error", e.getMessage(), null);
         e.printStackTrace();
       }
     } else {

--- a/packages/flutter_midi/android/src/main/java/com/appleeducate/fluttermidi/FlutterMidiPlugin.java
+++ b/packages/flutter_midi/android/src/main/java/com/appleeducate/fluttermidi/FlutterMidiPlugin.java
@@ -38,9 +38,12 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         synth.getChannels()[0].programChange(0);
         synth.getChannels()[1].programChange(1);
         recv = synth.getReceiver();
+        result.success("success");
       } catch (IOException e) {
+        result.error(e.getMessage());
         e.printStackTrace();
       } catch (MidiUnavailableException e) {
+        result.error(e.getMessage());
         e.printStackTrace();
       }
     } else if (call.method.equals("change_sound")) {
@@ -54,9 +57,12 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         synth.getChannels()[0].programChange(0);
         synth.getChannels()[1].programChange(1);
         recv = synth.getReceiver();
+        result.success("success");
       } catch (IOException e) {
+        result.error(e.getMessage());
         e.printStackTrace();
       } catch (MidiUnavailableException e) {
+        result.error(e.getMessage());
         e.printStackTrace();
       }
     } else if (call.method.equals("play_midi_note")) {
@@ -65,7 +71,9 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         ShortMessage msg = new ShortMessage();
         msg.setMessage(ShortMessage.NOTE_ON, 0, _note, 127);
         recv.send(msg, -1);
+        result.success("success");
       } catch (InvalidMidiDataException e) {
+        result.error(e.getMessage());
         e.printStackTrace();
       }
     } else if (call.method.equals("stop_midi_note")) {
@@ -74,10 +82,13 @@ public class FlutterMidiPlugin implements MethodCallHandler {
         ShortMessage msg = new ShortMessage();
         msg.setMessage(ShortMessage.NOTE_OFF, 0, _note, 127);
         recv.send(msg, -1);
+        result.success("success");
       } catch (InvalidMidiDataException e) {
+        result.error(e.getMessage());
         e.printStackTrace();
       }
     } else {
+      result.notImplemented();
     }
   }
 }

--- a/packages/flutter_midi/lib/flutter_midi.dart
+++ b/packages/flutter_midi/lib/flutter_midi.dart
@@ -66,6 +66,8 @@ class FlutterMidi {
     final Map<dynamic, dynamic> mapData = <dynamic, dynamic>{};
     print("Pressed: $midi");
     mapData["note"] = midi;
-    return await _channel.invokeMethod('play_midi_note', mapData);
+    final String result =
+        await _channel.invokeMethod('play_midi_note', mapData);
+    return result;
   }
 }


### PR DESCRIPTION
Stumbled on an issue where my app was hanging whenever I would wait for the `play_midi_note` platform call to resolve.

Following Flutter's guideline to [writing platform code](https://flutter.dev/docs/development/platform-integration/platform-channels#example-java), the `result` argument is now being populated with success/error results.